### PR TITLE
Made compatible with authenticated kafka brokers (ccloud in particular)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>club-topicana</artifactId>
         <groupId>com.github.ftrossbach</groupId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.17</version>
+            <version>1.18</version>
         </dependency>
 
 

--- a/core/src/test/java/com/github/ftrossbach/club_topicana/core/IntegrationTest.java
+++ b/core/src/test/java/com/github/ftrossbach/club_topicana/core/IntegrationTest.java
@@ -18,11 +18,14 @@ package com.github.ftrossbach.club_topicana.core;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.Properties;
-
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -37,6 +40,7 @@ public class IntegrationTest {
     private static EmbeddedKafka embeddedKafkaCluster = null;
 
     private TopicComparer unitUnderTest;
+    private static Properties props;
 
 
     @BeforeAll
@@ -45,7 +49,7 @@ public class IntegrationTest {
         embeddedKafkaCluster.start();
         bootstrapServers = embeddedKafkaCluster.bootstrapServers();
 
-        Properties props = new Properties();
+        props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         try(AdminClient ac = AdminClient.create(props)){
 
@@ -60,7 +64,7 @@ public class IntegrationTest {
 
     @BeforeEach
     public void setUp(){
-        unitUnderTest = new TopicComparer(bootstrapServers);
+        unitUnderTest = new TopicComparer(props);
     }
 
     @Nested

--- a/core/src/test/java/com/github/ftrossbach/club_topicana/core/MultiBrokerIntegrationTest.java
+++ b/core/src/test/java/com/github/ftrossbach/club_topicana/core/MultiBrokerIntegrationTest.java
@@ -15,14 +15,17 @@
  */
 package com.github.ftrossbach.club_topicana.core;
 
-import org.apache.kafka.clients.admin.*;
-import org.apache.kafka.common.config.ConfigResource;
-import org.junit.jupiter.api.*;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,6 +38,7 @@ public class MultiBrokerIntegrationTest {
     private static EmbeddedKafka embeddedKafkaCluster = null;
 
     private TopicComparer unitUnderTest;
+    private static Properties props;
 
 
     @BeforeAll
@@ -44,7 +48,7 @@ public class MultiBrokerIntegrationTest {
         embeddedKafkaCluster.start();
         bootstrapServers = embeddedKafkaCluster.bootstrapServers();
 
-        Properties props = new Properties();
+        props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         try(AdminClient ac = AdminClient.create(props)){
 
@@ -57,7 +61,7 @@ public class MultiBrokerIntegrationTest {
 
     @BeforeEach
     public void setUp(){
-        unitUnderTest = new TopicComparer(bootstrapServers);
+        unitUnderTest = new TopicComparer(props);
     }
 
 

--- a/kafka-clients/pom.xml
+++ b/kafka-clients/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.github.ftrossbach</groupId>
         <artifactId>club-topicana</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <groupId>com.github.ftrossbach</groupId>
@@ -94,5 +94,5 @@
         </plugins>
     </build>
 
-    
+
 </project>

--- a/kafka-clients/src/main/java/com/github/ftrossbach/club_topicana/kafka_clients/KafkaConsumerFactory.java
+++ b/kafka-clients/src/main/java/com/github/ftrossbach/club_topicana/kafka_clients/KafkaConsumerFactory.java
@@ -20,9 +20,9 @@ import com.github.ftrossbach.club_topicana.core.ExpectedTopicConfiguration;
 import com.github.ftrossbach.club_topicana.core.MismatchedTopicConfigException;
 import com.github.ftrossbach.club_topicana.core.TopicComparer;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.Deserializer;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
@@ -46,7 +46,7 @@ public class KafkaConsumerFactory {
 
     public static <K, V> Consumer<K, V> consumer(Properties properties, Deserializer<K> keySerializer, Deserializer<V> valueSerializer, Collection<ExpectedTopicConfiguration> expectedTopicConfiguration) throws MismatchedTopicConfigException {
 
-        TopicComparer comparer = new TopicComparer(properties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        TopicComparer comparer = new TopicComparer(properties);
         ComparisonResult result = comparer.compare(expectedTopicConfiguration);
         if (result.ok()) {
             return new KafkaConsumer<>(properties, keySerializer, valueSerializer);

--- a/kafka-clients/src/main/java/com/github/ftrossbach/club_topicana/kafka_clients/KafkaProducerFactory.java
+++ b/kafka-clients/src/main/java/com/github/ftrossbach/club_topicana/kafka_clients/KafkaProducerFactory.java
@@ -21,8 +21,8 @@ import com.github.ftrossbach.club_topicana.core.MismatchedTopicConfigException;
 import com.github.ftrossbach.club_topicana.core.TopicComparer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serializer;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
@@ -46,7 +46,7 @@ public class KafkaProducerFactory {
 
     public static <K,V>  Producer<K,V> producer(Properties properties, Serializer<K> keySerializer, Serializer<V> valueSerializer, Collection<ExpectedTopicConfiguration> expectedTopicConfiguration) throws MismatchedTopicConfigException{
 
-        TopicComparer comparer = new TopicComparer(properties.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        TopicComparer comparer = new TopicComparer(properties);
         ComparisonResult result = comparer.compare(expectedTopicConfiguration);
         if(result.ok()){
             return new KafkaProducer<>(properties, keySerializer, valueSerializer);

--- a/kafka-clients/src/test/java/com/github/ftrossbach/club_topicana/kafka_clients/KafkaConsumerFactoryIntegrationTest.java
+++ b/kafka-clients/src/test/java/com/github/ftrossbach/club_topicana/kafka_clients/KafkaConsumerFactoryIntegrationTest.java
@@ -33,13 +33,14 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
 import java.time.Duration;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
 
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
@@ -95,7 +96,7 @@ public class KafkaConsumerFactoryIntegrationTest {
             assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
 
                 while(true){
-                    ConsumerRecords<String, String> records = consumer.poll(100);
+                    ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
                     if(! records.isEmpty()) {
                         break;
                     }
@@ -125,7 +126,7 @@ public class KafkaConsumerFactoryIntegrationTest {
             assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
 
                 while(true){
-                    ConsumerRecords<String, String> records = consumer.poll(100);
+                    ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
                     if(! records.isEmpty()) {
                         break;
                     }
@@ -151,7 +152,7 @@ public class KafkaConsumerFactoryIntegrationTest {
             assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
 
                 while(true){
-                    ConsumerRecords<String, String> records = consumer.poll(100);
+                    ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
                     if(! records.isEmpty()) {
                         break;
                     }
@@ -177,7 +178,7 @@ public class KafkaConsumerFactoryIntegrationTest {
             assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
 
                 while(true){
-                    ConsumerRecords<String, String> records = consumer.poll(100);
+                    ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
                     if(! records.isEmpty()) {
                         break;
                     }

--- a/kafka-streams/pom.xml
+++ b/kafka-streams/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.github.ftrossbach</groupId>
         <artifactId>club-topicana</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <groupId>com.github.ftrossbach</groupId>

--- a/kafka-streams/src/main/java/com/github/ftrossbach/club_topicana/kafka_streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/com/github/ftrossbach/club_topicana/kafka_streams/KafkaStreamsFactory.java
@@ -19,27 +19,22 @@ import com.github.ftrossbach.club_topicana.core.ComparisonResult;
 import com.github.ftrossbach.club_topicana.core.ExpectedTopicConfiguration;
 import com.github.ftrossbach.club_topicana.core.MismatchedTopicConfigException;
 import com.github.ftrossbach.club_topicana.core.TopicComparer;
-import joptsimple.internal.Strings;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+
 import java.util.Collection;
 import java.util.Properties;
 
 public class KafkaStreamsFactory {
 
-    public static KafkaStreams streams(Topology topology, Properties props, Collection<ExpectedTopicConfiguration> expectedTopicConfiguration){
-        return streams(topology, new StreamsConfig(props), expectedTopicConfiguration);
-    }
-
-    public static KafkaStreams streams(Topology topology, StreamsConfig config, Collection<ExpectedTopicConfiguration> expectedTopicConfiguration){
+    public static KafkaStreams streams(Topology topology, Properties config, Collection<ExpectedTopicConfiguration> expectedTopicConfiguration){
         return streams(topology, config, new DefaultKafkaClientSupplier(), expectedTopicConfiguration);
     }
 
-    public static KafkaStreams streams(Topology topology, StreamsConfig config, KafkaClientSupplier clientSupplier, Collection<ExpectedTopicConfiguration> expectedTopicConfiguration){
-        TopicComparer comparer = new TopicComparer(Strings.join(config.getList(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG), ","));
+    public static KafkaStreams streams(Topology topology, Properties config, KafkaClientSupplier clientSupplier, Collection<ExpectedTopicConfiguration> expectedTopicConfiguration){
+        TopicComparer comparer = new TopicComparer(config);
         ComparisonResult result = comparer.compare(expectedTopicConfiguration);
         if (result.ok()) {
             return new KafkaStreams(topology, config, clientSupplier);

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.github.ftrossbach</groupId>
     <artifactId>club-topicana</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0</version>
     <modules>
         <module>core</module>
         <module>kafka-clients</module>
@@ -49,7 +49,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit-platform.version>1.0.2</junit-platform.version>
         <junit-jupiter.version>5.0.1</junit-jupiter.version>
-        <kafka.version>1.0.0</kafka.version>
+        <kafka.version>2.0.0</kafka.version>
     </properties>
 
     <dependencyManagement>
@@ -140,6 +140,15 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.github.ftrossbach</groupId>
         <artifactId>club-topicana</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <groupId>com.github.ftrossbach</groupId>

--- a/spring/src/main/java/com/github/ftrossbach/club_topicana/spring/ClubTopicanaConfiguration.java
+++ b/spring/src/main/java/com/github/ftrossbach/club_topicana/spring/ClubTopicanaConfiguration.java
@@ -19,13 +19,13 @@ import com.github.ftrossbach.club_topicana.core.ComparisonResult;
 import com.github.ftrossbach.club_topicana.core.ConfigParser;
 import com.github.ftrossbach.club_topicana.core.ExpectedTopicConfiguration;
 import com.github.ftrossbach.club_topicana.core.TopicComparer;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import java.util.Collection;
-
-
-import static java.util.stream.Collectors.toMap;
+import java.util.Properties;
 
 @Configuration
 public class ClubTopicanaConfiguration {
@@ -42,7 +42,9 @@ public class ClubTopicanaConfiguration {
 
         Collection<ExpectedTopicConfiguration> expectedConfig = configParser.parseTopicConfiguration(configFile);
 
-        ComparisonResult result = new TopicComparer(bootstrapServers).compare(expectedConfig);
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        ComparisonResult result = new TopicComparer(props).compare(expectedConfig);
         return result;
     }
 


### PR DESCRIPTION
includes: 
- changes in TopicCompare class to take full properties rather than just the bootstrap servers. This allows authentication properties etc... to be applied for the admin client.
- bump of kafka version to 2.0.0 - adjusted tests and accounted for new exception on topic not found in kafka admin client
- bump of version to 0.2.0 to account for breaking change in KafkaStreamsFactory (StreamsConfig is now deprecated)
- bump of snappy version to 1.18 (from 1.17)
